### PR TITLE
Check case if `REMOTE_USER` key does not exist in `$_SERVER` global variable

### DIFF
--- a/action.php
+++ b/action.php
@@ -34,7 +34,7 @@ class action_plugin_showlogin extends DokuWiki_Action_Plugin {
       global $ACT;
 
       # If user is not logged in and access to page is denied, show login form
-      if (($ACT == 'denied') && (! $_SERVER['REMOTE_USER'])) {
+      if (($ACT == 'denied') && (!array_key_exists('REMOTE_USER', $_SERVER) || ! $_SERVER['REMOTE_USER'])) {
 	$event->preventDefault(); // prevent "Access denied" page from showing
 	html_login(); // show login dialog instead
       }


### PR DESCRIPTION
This PR introduces an extra check in the case `REMOTE_USER` is not present in `$_SERVER` global variable keys. This was encountered when updating our server's PHP version from 7.4 to 8.0.